### PR TITLE
BUG012 - Criação de novo endpoint para análise de release

### DIFF
--- a/src/releases/service.py
+++ b/src/releases/service.py
@@ -3,16 +3,21 @@ from releases.models import Release
 
 
 def get_planned_values(release: Release):
-    planned_values = {}
+    planned_values = []
 
-    for characteristic, value in release.goal.data.items():
-        planned_values[characteristic] = value / 100
+    for characteristic_name, characteristic_value in release.goal.data.items():
+        characteristic = {
+            'name': characteristic_name,
+            'value': characteristic_value / 100,
+        }
+
+        planned_values.append(characteristic)
 
     return planned_values
 
 
 def get_accomplished_values(release: Release, repositories_ids: list[int]):
-    result_calculated = CalculatedCharacteristic.objects.filter(release=release).all()
+    result_calculated = CalculatedCharacteristic.objects.filter(release=release).all().order_by('-created_at')[:2]
 
     if len(result_calculated) == 0:
         result_calculated = (
@@ -21,7 +26,41 @@ def get_accomplished_values(release: Release, repositories_ids: list[int]):
             )
         )
 
-    return get_process_calculated_characteristics(list(result_calculated))
+    return get_process_calculated_characteristics_to_list(list(result_calculated))
+
+
+def get_process_calculated_characteristics_to_list(
+    result_calculated: list[CalculatedCharacteristic],
+):
+    accomplished = []
+
+    for calculated_characteristic in result_calculated:
+
+        repository_name = calculated_characteristic.repository.name
+        characteristic_name = calculated_characteristic.characteristic.key
+        characteristic_value = calculated_characteristic.value
+
+        characteristic = {
+            'name': characteristic_name,
+            'value': characteristic_value,
+        }
+
+        isRepositoryInserted = False
+
+        for repository in accomplished:
+            if repository['repository_name'] == repository_name:
+                isRepositoryInserted = True
+                if all(characteristic['name'] != characteristic_name
+                       for characteristic in repository['characteristics']):
+                    repository['characteristics'].append(characteristic)
+
+        if not isRepositoryInserted:
+            accomplished.append({
+                'repository_name': repository_name,
+                'characteristics': [characteristic]
+            })
+
+    return accomplished
 
 
 def get_process_calculated_characteristics(

--- a/src/releases/service.py
+++ b/src/releases/service.py
@@ -1,6 +1,7 @@
 from characteristics.models import CalculatedCharacteristic
 from releases.models import Release
 
+
 def get_planned_values(release: Release):
     planned_values = {}
 
@@ -8,6 +9,7 @@ def get_planned_values(release: Release):
         planned_values[characteristic] = value / 100
 
     return planned_values
+
 
 def get_accomplished_values(release: Release, repositories_ids: list[int]):
     result_calculated = CalculatedCharacteristic.objects.filter(release=release).all()

--- a/src/releases/service.py
+++ b/src/releases/service.py
@@ -1,4 +1,25 @@
 from characteristics.models import CalculatedCharacteristic
+from releases.models import Release
+
+def get_planned_values(release: Release):
+    planned_values = {}
+
+    for characteristic, value in release.goal.data.items():
+        planned_values[characteristic] = value / 100
+
+    return planned_values
+
+def get_accomplished_values(release: Release, repositories_ids: list[int]):
+    result_calculated = CalculatedCharacteristic.objects.filter(release=release).all()
+
+    if len(result_calculated) == 0:
+        result_calculated = (
+            get_calculated_characteristic_by_ids_repositories(
+                repositories_ids
+            )
+        )
+
+    return get_process_calculated_characteristics(list(result_calculated))
 
 
 def get_process_calculated_characteristics(

--- a/src/releases/tests/test_releases_endpoints.py
+++ b/src/releases/tests/test_releases_endpoints.py
@@ -29,8 +29,7 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
             product=self.product,
             data={
                 'reliability': 53,
-                'maintainability': 53,
-                'functional_suitability': 53,
+                'maintainability': 53
             },
         )
         self.url_default = f'/api/v1/organizations/{self.org.id}/products/{self.product.id}/create/release/'
@@ -442,9 +441,13 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
             path=f'{self.url_default}999/analysis_data/'
         )
 
-        self.assertEqual(response.status_code, 200)
-        assert 'reliability' in response.json()['planned'].keys()
-        assert 'maintainability' in response.json()['planned'].keys()
+        planned = [
+            {'name': 'reliability', 'value': 0.53},
+            {'name': 'maintainability', 'value': 0.53},
+        ]
+
+        assert response.status_code == 200
+        assert response.json()['planned'] == planned
 
     def test_get_analysis_data_release_finished(self):
         Release.objects.create(
@@ -491,5 +494,23 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
             path=f'{self.url_default}999/analysis_data/'
         )
 
+        accomplished = [
+            {
+                'repository_name': 'Repository_name',
+                'characteristics': [
+                    {'name': 'maintainability', 'value': 1.0},
+                    {'name': 'reliability', 'value': 1.0},
+                ]
+            }
+        ]
+
         assert response.status_code == 200
-        assert response.json()['accomplished'] == {'Repository_name': {'maintainability': 1.0, 'reliability': 1.0}}
+        assert response.json()['accomplished'] == accomplished
+
+    def test_get_analysis_data_release_not_found(self):
+        response = self.client.get(
+            path=f'{self.url_default}999/analysis_data/'
+        )
+
+        assert response.status_code == 404
+        assert response.json()['detail'] == 'Release não encontrada'

--- a/src/releases/views.py
+++ b/src/releases/views.py
@@ -23,7 +23,6 @@ from rest_framework.permissions import IsAuthenticated
 
 from core.transformations import diff, norm_diff
 
-import numpy as np
 
 class CreateReleaseModelViewSet(viewsets.ModelViewSet):
     authentication_classes = (TokenAuthentication,)
@@ -159,14 +158,14 @@ class CreateReleaseModelViewSet(viewsets.ModelViewSet):
 
         release = Release.objects.filter(id=release_id).first()
 
-        if release == None:
+        if release is None:
             return Response({'detail': 'Release não encontrada'}, status=404)
 
         repositories_ids = list(
-                Repository.objects.filter(product_id=product_pk)
-                .values_list('id', flat=True)
-                .all()
-            )
+            Repository.objects.filter(product_id=product_pk)
+            .values_list('id', flat=True)
+            .all()
+        )
 
         serialized_release = ReleaseAllSerializer(release).data
         planned_values = get_planned_values(release)


### PR DESCRIPTION
## Descrição
O atual endpoint realiza uma operação de diff para definir os valores de "accomplished", esse comportamento está errado visto que nesse campo deve ser mostrado somente os valores obtidos pela coleta de métricas.

[BUG012](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/65)

## Porque este Pull Request é necessário?
O campo atualmente exibe um valor incorreto para o usuário.

## Critérios de aceitação

1. [x] Endpoint deve retornar valor coletado para cada repositório no campo "accomplished"
2. [x] Deve haver testes para garantir o funcionamento

Closes #65

Endpoint **antigo**:
![image](https://github.com/user-attachments/assets/d963c640-1fd1-4dc6-84bc-3665de566af8)

Endpoint **novo**:
![image](https://github.com/user-attachments/assets/3ea141e6-1d91-4d5b-909d-f5e44de1b122)


