### PR TITLE
US003 - Eu, Valéria, desejo utilizar o norm_diff na interface web para que eu consiga ver a diferenca entre release planejada e realizada

### DIFF
--- a/src/releases/service.py
+++ b/src/releases/service.py
@@ -96,6 +96,10 @@ def calculate_norm_diff(planned_values, accomplished_characteristics):
                       + 'was not found in the accomplished characteristics.')
                 return None
 
+            if accomplished_value < 0 or accomplished_value > 1:
+                print('Accomplished characteristic value should be between 0 and 1.')
+                return None
+
             rd.append(accomplished_value)
 
         return norm_diff(np.array(rp), np.array(rd))

--- a/src/releases/service.py
+++ b/src/releases/service.py
@@ -64,11 +64,13 @@ def get_process_calculated_characteristics_to_list(
 
     return accomplished
 
+
 def get_norm_diff(planned_values, accomplished_values):
     for repository in accomplished_values:
         repository['norm_diff'] = calculate_norm_diff(planned_values, repository['characteristics'])
 
     return accomplished_values
+
 
 def calculate_norm_diff(planned_values, accomplished_characteristics):
     if len(planned_values) != len(accomplished_characteristics):
@@ -94,11 +96,9 @@ def calculate_norm_diff(planned_values, accomplished_characteristics):
                       + 'was not found in the accomplished characteristics.')
                 return None
 
-
             rd.append(accomplished_value)
 
         return norm_diff(np.array(rp), np.array(rd))
-
 
 
 def get_process_calculated_characteristics(

--- a/src/releases/service.py
+++ b/src/releases/service.py
@@ -1,5 +1,7 @@
 from characteristics.models import CalculatedCharacteristic
 from releases.models import Release
+from core.transformations import norm_diff
+import numpy as np
 
 
 def get_planned_values(release: Release):
@@ -62,8 +64,45 @@ def get_process_calculated_characteristics_to_list(
 
     return accomplished
 
+def get_norm_diff(planned_values, accomplished_values):
+    for repository in accomplished_values:
+        repository['norm_diff'] = calculate_norm_diff(planned_values, repository['characteristics'])
+
+    return accomplished_values
+
+def calculate_norm_diff(planned_values, accomplished_characteristics):
+    if len(planned_values) != len(accomplished_characteristics):
+        print('The number of planned and accomplished characteristics should be the same.')
+        return None
+
+    else:
+        rp = []
+        rd = []
+
+        for planned_characteristic in planned_values:
+            planned_characteristic_name = planned_characteristic['name']
+
+            rp.append(planned_characteristic['value'])
+            accomplished_value = None
+
+            for accomplished_characteristic in accomplished_characteristics:
+                if accomplished_characteristic['name'] == planned_characteristic_name:
+                    accomplished_value = accomplished_characteristic['value']
+
+            if accomplished_value is None:
+                print(f'Planned characteristic {planned_characteristic_name}'
+                      + 'was not found in the accomplished characteristics.')
+                return None
+
+
+            rd.append(accomplished_value)
+
+        return norm_diff(np.array(rp), np.array(rd))
+
+
 
 def get_process_calculated_characteristics(
+
     result_calculated: list[CalculatedCharacteristic],
 ):
     accomplished = {}

--- a/src/releases/tests/test_releases_endpoints.py
+++ b/src/releases/tests/test_releases_endpoints.py
@@ -500,7 +500,8 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
                 'characteristics': [
                     {'name': 'maintainability', 'value': 1.0},
                     {'name': 'reliability', 'value': 1.0},
-                ]
+                ],
+                'norm_diff': 0.8867924528301886
             }
         ]
 

--- a/src/releases/tests/test_releases_endpoints.py
+++ b/src/releases/tests/test_releases_endpoints.py
@@ -461,13 +461,6 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
             goal=self.goal,
         )
 
-        repository = Repository.objects.create(
-            id=1,
-            name='Repository_name',
-            key='2023-2-Msg',
-            product=self.product,
-        )
-
         reliability = SupportedCharacteristic.objects.filter(
             key='reliability'
         ).first()
@@ -476,18 +469,46 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
             key='maintainability'
         ).first()
 
+        repository1 = Repository.objects.create(
+            id=1,
+            name='Repository_name',
+            key='2023-2-Msg',
+            product=self.product,
+        )
+
         CalculatedCharacteristic.objects.create(
             release_id=999,
             characteristic=reliability,
-            repository=repository,
+            repository=repository1,
             value=1,
         )
 
         CalculatedCharacteristic.objects.create(
             release_id=999,
             characteristic=maintainability,
-            repository=repository,
+            repository=repository1,
             value=1,
+        )
+
+        repository2 = Repository.objects.create(
+            id=2,
+            name='Repository_name 2',
+            key='2023-2-Msg-2',
+            product=self.product,
+        )
+
+        CalculatedCharacteristic.objects.create(
+            release_id=999,
+            characteristic=reliability,
+            repository=repository2,
+            value=1,
+        )
+
+        CalculatedCharacteristic.objects.create(
+            release_id=999,
+            characteristic=maintainability,
+            repository=repository2,
+            value=1.1,
         )
 
         response = self.client.get(
@@ -502,6 +523,14 @@ class ReleaseEndpointsTestCase(APITestCaseExpanded):
                     {'name': 'reliability', 'value': 1.0},
                 ],
                 'norm_diff': 0.8867924528301886
+            },
+            {
+                'repository_name': 'Repository_name 2',
+                'characteristics': [
+                    {'name': 'maintainability', 'value': 1.1},
+                    {'name': 'reliability', 'value': 1.0},
+                ],
+                'norm_diff': None
             }
         ]
 

--- a/src/releases/views.py
+++ b/src/releases/views.py
@@ -9,6 +9,7 @@ from organizations.models import Repository
 from characteristics.models import CalculatedCharacteristic
 from releases.service import (
     get_accomplished_values,
+    get_norm_diff,
     get_planned_values,
     get_process_calculated_characteristics,
     get_calculated_characteristic_by_ids_repositories,
@@ -21,7 +22,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
-from core.transformations import diff, norm_diff
+from core.transformations import diff
 
 
 class CreateReleaseModelViewSet(viewsets.ModelViewSet):
@@ -170,11 +171,12 @@ class CreateReleaseModelViewSet(viewsets.ModelViewSet):
         serialized_release = ReleaseAllSerializer(release).data
         planned_values = get_planned_values(release)
         accomplished_values = get_accomplished_values(release, repositories_ids)
+        accomplished_with_norm_diff = get_norm_diff(planned_values, accomplished_values)
 
         return Response(
             {
                 'release': serialized_release,
                 'planned': planned_values,
-                'accomplished': accomplished_values,
+                'accomplished': accomplished_with_norm_diff,
             }
         )


### PR DESCRIPTION
# Mudança tal

## Descrição
Um novo campo, contando o norm_diff, foi adicionado no retorno do endpoint de análise entre release planejada e release desenvolvida.

[US003](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/50)

## Porque este Pull Request é necessário?
É uma melhoria que adiciona um novo elemento para análise de dados.

## Critérios de aceitação
(Exemplos de critérios de aceitação)

- [ ] Deve ser possível visualizar o valor obtido através da função norm_diff
- [ ] O valor deve ser apresentado no endpoint comparação de release planejada e desenvolvida (`GET `para `/api/v1/organizations/1/products/3/create/release/1/analysis_data/`)
- [ ] O norm_diff não deve ser calculado caso a quantidade de características planejadas seja diferente da quantidade realizada
- [ ] O norm_diff não deve ser calculado caso algum dos valores não esteja entre 0 e 1

Closes #50
